### PR TITLE
Fix for lsp-ui-peek-selection face setup

### DIFF
--- a/humanoid-themes.el
+++ b/humanoid-themes.el
@@ -844,7 +844,7 @@ or similar."
      `(lsp-ui-peek-line-number        ((,class (:foreground ,suc))))
      `(lsp-ui-peek-list               ((,class (:background ,bg4))))
      `(lsp-ui-peek-peek               ((,class (:background ,blue-bg-s))))
-     `(lsp-ui-peek-selection          ((,class (:background blue :foreground ,bg1 :weight bold))))
+     `(lsp-ui-peek-selection          ((,class (:background ,blue :foreground ,bg1 :weight bold))))
      `(lsp-ui-sideline-code-action    ((,class (:foreground ,highlight-dim))))
      `(lsp-ui-sideline-current-symbol ((,class (:inherit 'highlight))))
      `(lsp-ui-sideline-symbol-info    ((,class (:background ,bg0 :foreground ,act2 :extend t))))


### PR DESCRIPTION
Fix for a minor typo responsible for breaking emacs startup when lsp-ui is present and active (at least on Emacs master, haven't tried on earlier versions).