### PR TITLE
[faces] add support for orderless

### DIFF
--- a/humanoid-themes.el
+++ b/humanoid-themes.el
@@ -1057,6 +1057,12 @@ or similar."
      `(neo-file-link-face  ((,class (:foreground ,keyword))))
      `(neo-root-dir-face   ((,class (:inherit bold :foreground ,func))))
 
+     ;;; orderless
+     `(orderless-match-face-0 ((,class (:foreground, blue-light))))
+     `(orderless-match-face-1 ((,class (:foreground, orange-light))))
+     `(orderless-match-face-2 ((,class (:foreground ,green-light))))
+     `(orderless-match-face-3 ((,class (:foreground ,magenta-light))))
+
      ;;; org
      `(org-default                   ((,class (:inherit 'variable-pitch))))
      `(org-agenda-clocking           ((,class (:background ,highlight :foreground ,comp))))


### PR DESCRIPTION
This is a fantastic theme. It would be nice to add support for [orderless](https://github.com/oantolin/orderless) because its default colours do not look nice with the light theme:

before:
<img width="674" alt="before" src="https://user-images.githubusercontent.com/43703153/147371947-d34d7c43-8f87-4034-9e53-622e4b17cf11.png">

after change:
<img width="627" alt="now1" src="https://user-images.githubusercontent.com/43703153/147371949-7d552259-d07d-4202-b739-53f102968d15.png">

<img width="627" alt="now2" src="https://user-images.githubusercontent.com/43703153/147371953-e36478f4-53db-42dd-9312-3f4f7b5941b3.png">

