### PR TITLE
[faces] set all/only `hl-todo` keywords which are present

### DIFF
--- a/humanoid-themes.el
+++ b/humanoid-themes.el
@@ -1390,28 +1390,35 @@ or similar."
      ;;; ansi-color-names
      `(ansi-color-names-vector [,bg4 ,red ,green ,yellow ,blue ,magenta ,cyan ,base])
 
-     ;;; hl-todo
-     `(hl-todo-keyword-faces '(("HOLD"       . ,brown-fg)
-                               ("TODO"       . ,magenta)
-                               ("NEXT"       . ,purple)
-                               ("THEM"       . ,aqua)
-                               ("PROG"       . ,cyan)
-                               ("OKAY"       . ,suc)
-                               ("DONT"       . ,war)
-                               ("FAIL"       . ,err)
-                               ("BUG"        . ,red)
-                               ("DONE"       . ,suc)
-                               ("NOTE"       . ,yellow)
-                               ("KLUDGE"     . ,orange)
-                               ("HACK"       . ,green-fg)
-                               ("TEMP"       . ,gray)
-                               ("FIXME"      . ,red-fg)
-                               ("XXX+"       . ,var)
-                               ("REVIEW"     . ,brown)
-                               ("DEPRECATED" . ,blue-fg)
-                               ("\\?\\?\\?+" . ,meta)))
+;;; hl-todo
+     `(hl-todo-keyword-faces
+       `,(let ((new-list '(("HOLD"       . ,brown-fg)
+			   ("TODO"       . ,magenta)
+			   ("NEXT"       . ,purple)
+			   ("THEM"       . ,aqua)
+			   ("PROG"       . ,cyan)
+			   ("OKAY"       . ,suc)
+			   ("DONT"       . ,war)
+			   ("FAIL"       . ,err)
+			   ("BUG"        . ,red)
+			   ("DONE"       . ,suc)
+			   ("NOTE"       . ,yellow)
+			   ("KLUDGE"     . ,orange)
+			   ("HACK"       . ,green-fg)
+			   ("TEMP"       . ,gray)
+			   ("FIXME"      . ,red-fg)
+			   ("XXX+"       . ,var)
+			   ("REVIEW"     . ,brown)
+			   ("DEPRECATED" . ,blue-fg)
+			   ("\\?\\?\\?+" . ,meta))))
+	   (mapcar (lambda (pair)
+		     (if-let* ((word (car pair))
+			       (hex (assoc-default word new-list)))
+			 (cons word hex)
+		       pair))
+		   hl-todo-keyword-faces)))
 
-     ;;; pdf-tools
+;;; pdf-tools
      `(pdf-view-midnight-colors '(,base . ,bg1)))))
 
 


### PR DESCRIPTION
I load `hl-todo-mode` before my humanoid theme and add a new todo
(keyword . face) pair to `hl-todo-keyword-faces`. I was frustrated for
a while as to why this new pair didn't show up in actual operation.
The answer is that `humanoid-themes` overwrites
`hl-todo-keyword-faces` with a hardcoded value. 

All this is meant to achieve is to fix the faces in the list to the
relevant colours. This PR offers a more robust solution: for every
word in the actual list `hl-todo-keyword-faces` when the theme is set,
if that word appears in a canonical alist in the theme code, set the
colour/face to the one in the canonical alist. Otherwise, leave it
alone. This retains edits (additions and deletions) the user makes,
but still fixes the colours.

Original commit message for sole commit:

> Instead of hard-coding the value of `hl-todo-keyword-faces`, alter the
> value of any keyword in the list for which we have a value in the
> theme's list. This allows users to alter the list before loading the
> theme (and retain their own additions) while still using the theme
> colours where relevant.